### PR TITLE
pprint.{PPrint,Indent}: Add streamed implementations

### DIFF
--- a/pprint_test.go
+++ b/pprint_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015 Jean Niklas L'orange.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package edn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPPrintSimple(t *testing.T) {
+	inputs := []string{
+		"{}",
+		"[]",
+		"{:a 42}",
+	}
+
+	for _, input := range inputs {
+		buff := bytes.NewBuffer(nil)
+		if err := PPrint(buff, []byte(input), &PPrintOpts{}); err != nil {
+			t.Errorf(`PPrint("%s") failed, but expected success: %v`, input, err)
+		}
+
+		output := string(buff.Bytes())
+		if output != input {
+			t.Errorf(`Expected PPrint("%s") to be "%s"; was "%s"`, input, input, output)
+		}
+	}
+}


### PR DESCRIPTION
`pprint.PPrint` and `pprint.Indent` both read their input from a bytes slice and write their output in bytes buffer. This works great with small EDN strings but may take a lot of unnecessary memory when pretty-printing large EDNs. I implemented two variants called `pprint.PPrintStream` and `pprint.IndentStream` that use `io.Reader` and `io.Writer` arguments instead.

My use-case was a 55-MB EDN file that I read from `os.Stdin` and write to `os.Stdout`. Without the streamed implementation it takes ~9s to pretty-print it. With it (and `bufio.{Reader,Writer}`) it takes ~5.8s.

This PR doesn’t break the public API.