### PR TITLE
#12 adding a single quote as a valid symbol rune

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -230,6 +230,17 @@ func TestUnmarshalEDN(t *testing.T) {
 			t.Logf("Was %s", tm)
 		}
 	}
+
+	data = "#{:foo :bar :baz :rock'n'roll :ain't_going-anywhere}"
+	expected = testUnmarshalEDN("set elements")
+	err = UnmarshalString(data, &tm)
+	if err != nil {
+		t.Errorf("Expected '%s' to successfully read into testUnmarshalEDN", data)
+		t.Log(err.Error())
+	} else if expected != tm {
+		t.Error("Mismatch between testUnmarshalEDN unmarshaling and the expected value")
+		t.Logf("Was %s, expected %s", tm, expected)
+	}
 }
 
 type vectorCounter int

--- a/lexer.go
+++ b/lexer.go
@@ -102,7 +102,7 @@ func okSymbolFirst(r rune) bool {
 
 func okSymbol(r rune) bool {
 	switch r {
-	case '.', '*', '+', '!', '-', '_', '?', '$', '%', '&', '=', '<', '>', ':', '#':
+	case '.', '*', '+', '!', '-', '_', '?', '$', '%', '&', '=', '<', '>', ':', '#', '\'':
 		return true
 	}
 	return false


### PR DESCRIPTION
since an uber test is testing [only keywords](https://github.com/go-edn/edn/blob/v1/decoder_test.go#L178) in `testUnmarshalEDN`, it'd need to be changed to accommodate both: keywords and symbols, hence for now just added a test for `map[Keyword]bool`.