### PR TITLE
Fixes a bug in Compact

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -61,9 +61,9 @@ func Compact(dst *bytes.Buffer, src []byte) error {
 			start = pos
 		case lexEndPrev:
 			dst.Write(src[start:ppos])
-			needsDelim = tokNeedsDelim(lex.token)
 			lex.reset()
 			lss := lex.state(r)
+			needsDelim = tokNeedsDelim(lex.token)
 			switch lss {
 			case lexIgnore:
 				prevIgnore = r

--- a/compact_test.go
+++ b/compact_test.go
@@ -23,6 +23,12 @@ func TestConvert(t *testing.T) {
 	// Removes comments?
 	checkConvert(t, "; just a comment, I am ignored", "")
 	checkConvert(t, "foo;; bar\nbaz", "foo\nbaz")
+	// Doesn't break on delimiters
+	checkConvert(t, "f(x)", "f(x)")
+	checkConvert(t, "#a[1]", "#a[1]")
+	checkConvert(t, "#a #b[1]", "#a #b[1]")
+	checkConvert(t, "#a #b{:x 1}", "#a #b{:x 1}")
+	checkConvert(t, "#tag/a{:x 1}", "#tag/a{:x 1}")
 }
 
 func checkConvert(t *testing.T, input, expected string) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -39,6 +39,81 @@ func TestEncoding(t *testing.T) {
 		[]string{"foo", "bar"},
 	}
 	testEncode(t, val, `{the-set #{3 4}:slice #{"foo""bar"}}`)
+
+	val = Tag{
+		Tagname: "some/tag",
+		Value:   1,
+	}
+	testEncode(t, val, `#some/tag 1`)
+
+	val = Tag{
+		Tagname: "some/tag",
+		Value:   struct{ X int }{1},
+	}
+	testEncode(t, val, `#some/tag{:x 1}`)
+
+	val = Tag{
+		Tagname: "a",
+		Value: Tag{
+			Tagname: "b",
+			Value: Tag{
+				Tagname: "c",
+				Value:   nil,
+			},
+		},
+	}
+	testEncode(t, val, `#a #b #c nil`)
+
+	val = Tag{
+		Tagname: "a",
+		Value: Tag{
+			Tagname: "b",
+			Value:   1,
+		},
+	}
+	testEncode(t, val, `#a #b 1`)
+
+	val = Tag{
+		Tagname: "a",
+		Value: Tag{
+			Tagname: "b",
+			Value:   "c",
+		},
+	}
+	testEncode(t, val, `#a #b"c"`)
+
+	val = Tag{
+		Tagname: "a",
+		Value:   []int{1},
+	}
+	testEncode(t, val, `#a[1]`)
+
+	val = Tag{
+		Tagname: "a",
+		Value: Tag{
+			Tagname: "b",
+			Value:   []int{1},
+		},
+	}
+	testEncode(t, val, `#a #b[1]`)
+
+	val = Tag{
+		Tagname: "some/tag",
+		Value: Tag{
+			Tagname: "inner",
+			Value:   struct{ X int }{1},
+		},
+	}
+	testEncode(t, val, `#some/tag #inner{:x 1}`)
+
+	val = A{}
+	testEncode(t, val, `#tag/a{:x 1}`)
+
+	val = Tag{
+		Tagname: "outer",
+		Value:   A{},
+	}
+	testEncode(t, val, `#outer #tag/a{:x 1}`)
 }
 
 func testEncode(t *testing.T, val interface{}, expects string) {
@@ -48,4 +123,14 @@ func testEncode(t *testing.T, val interface{}, expects string) {
 	} else if !bytes.Equal([]byte(expects), bs) {
 		t.Errorf("Expected to see '%s', but got '%s' instead", expects, string(bs))
 	}
+}
+
+type A struct{}
+
+func (a A) MarshalEDN() ([]byte, error) {
+	t := Tag{
+		Tagname: "tag/a",
+		Value:   struct{ X int }{1},
+	}
+	return Marshal(t)
 }

--- a/types.go
+++ b/types.go
@@ -63,7 +63,7 @@ type Tag struct {
 }
 
 func (t Tag) String() string {
-	return fmt.Sprintf("#%s %s", t.Tagname, t.Value)
+	return fmt.Sprintf("#%s %v", t.Tagname, t.Value)
 }
 
 func (t Tag) MarshalEDN() ([]byte, error) {


### PR DESCRIPTION
I ended up narrowing it down to `Compact("f(x)") == "f(�x)"`.

There's a bunch of test cases that came in during the process of narrowing it down -- not sure if you want to keep them all?

The fix seems to make sense to me, but I can't claim to have really understood the states of `Compact`.

