### PR TITLE
two crashing decoder tests, unhashable types

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -447,3 +447,19 @@ func TestNilNotEmptyString(t *testing.T) {
 		t.Error("Expected nil to not be a string")
 	}
 }
+
+func TestUnhashableBigInt(t *testing.T) {
+	input := "#{0N}"
+	var val interface{}
+	if err := UnmarshalString(input, &val); err != nil {
+		t.Errorf("unexpected parsing error: %q: %s", input, err)
+	}
+}
+
+func TestUnhashableTaggedList(t *testing.T) {
+	input := "{#g()0}"
+	var val interface{}
+	if err := UnmarshalString(input, &val); err != nil {
+		t.Errorf("unexpected parsing error: %q: %s", input, err)
+	}
+}


### PR DESCRIPTION
Seems that there's problems with using interface{} or big integers
in sets or as map keys.

Intrigued by how things like #15 might be caught earlier, I tried to rediscover that bug by fuzzing (with https://github.com/dvyukov/go-fuzz). Didn't manage to do that, but I did uncover some decoder crashes.
