### PR TITLE
Remove extra tab in README.md's marshal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func ReturnData() (Person, error) {
 If you want to write that user again, just `Marshal` it:
 
 ```go
-	bs, err := edn.Marshal(user)
+bs, err := edn.Marshal(user)
 ```
 
 ## Dependencies


### PR DESCRIPTION
## What

* Remove `\t` in the marshal example source code